### PR TITLE
fix-earn-icon

### DIFF
--- a/src/views/Bank/components/Harvest.tsx
+++ b/src/views/Bank/components/Harvest.tsx
@@ -29,6 +29,7 @@ const Harvest: React.FC<HarvestProps> = ({ bank }) => {
   const tShareStats = useShareStats();
 
   const tokenName = bank.earnTokenName === '3SHARES' ? '3SHARES' : '3OMB';
+  const tokenEarn = bank.earnTokenName === '3OMB' ? 'TOMB' : 'TSHARE';
   const tokenStats = bank.earnTokenName === '3SHARES' ? tShareStats : tombStats;
   const tokenPriceInDollars = useMemo(
     () => (tokenStats ? Number(tokenStats.priceInDollars).toFixed(2) : null),
@@ -41,7 +42,7 @@ const Harvest: React.FC<HarvestProps> = ({ bank }) => {
         <StyledCardContentInner>
           <StyledCardHeader>
             <CardIcon>
-              <TokenSymbol symbol={bank.earnToken.symbol} />
+              <TokenSymbol symbol={tokenEarn} />
             </CardIcon>
             <Value value={getDisplayBalance(earnings)} />
             <Label text={`≈ $${earnedInDollars}`} />


### PR DESCRIPTION
The var bank.earnToken.symbol returns different names that do not match we the symbols are in the Symbols.ts file. I created a conditional to set the earn token name.

User reported this issue.

Before( the icon for 3SHARE in Earned section is showing the 3OMB token)
![Screen Shot 2022-02-10 at 3 47 04 PM](https://user-images.githubusercontent.com/5277988/153514874-f4e9f95a-4063-42f4-85eb-7b8c3f78c86a.png)


After(the icon for 3SHARE in earned is correct and also if we go to the Genesis pool it shows the 3OMB token, meaning conditional is working)
![Screen Shot 2022-02-10 at 5 30 51 PM](https://user-images.githubusercontent.com/5277988/153514963-50ef1c89-954c-48fd-8206-781b81099ce4.png)

