### PR TITLE
Fix wallet text color and alignment

### DIFF
--- a/src/components/Nav/AccountModal.tsx
+++ b/src/components/Nav/AccountModal.tsx
@@ -30,7 +30,7 @@ const AccountModal: React.FC<ModalProps> = ({ onDismiss }) => {
           <TokenSymbol symbol="TOMB" />
           <StyledBalance>
             <StyledValue>{displayTombBalance}</StyledValue>
-            <Label text="3OMB Available" />
+            <Label text="3OMB Available" variant="primary" />
           </StyledBalance>
         </StyledBalanceWrapper>
 
@@ -38,7 +38,7 @@ const AccountModal: React.FC<ModalProps> = ({ onDismiss }) => {
           <TokenSymbol symbol="TSHARE" />
           <StyledBalance>
             <StyledValue>{displayTshareBalance}</StyledValue>
-            <Label text="3SHARE Available" />
+            <Label text="3SHARE Available" variant="primary" />
           </StyledBalance>
         </StyledBalanceWrapper>
 
@@ -46,7 +46,7 @@ const AccountModal: React.FC<ModalProps> = ({ onDismiss }) => {
           <TokenSymbol symbol="TBOND" />
           <StyledBalance>
             <StyledValue>{displayTbondBalance}</StyledValue>
-            <Label text="3BOND Available" />
+            <Label text="3BOND Available" variant="primary" />
           </StyledBalance>
         </StyledBalanceWrapper>
       </Balances>
@@ -64,6 +64,7 @@ const StyledBalance = styled.div`
   align-items: center;
   display: flex;
   flex-direction: column;
+  text-align: center;
 `;
 
 const Balances = styled.div`


### PR DESCRIPTION
similar to #7 tokens name on the wallet summary were not readable.

 * Changed font color to primary from theme
 * Aligned center for mobile devices

![image](https://user-images.githubusercontent.com/14729459/153690567-e32e2a29-7638-4ce0-a9b6-9e5817a63549.png)
