### PR TITLE
fix mobile menu background color

### DIFF
--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -45,6 +45,7 @@ const useStyles = makeStyles((theme) => ({
   drawer: {
     width: 240,
     flexShrink: 0,
+    backgroundColor: 'var(--accent)'
   },
   drawerPaper: {
     width: 240,


### PR DESCRIPTION
QoL fix.

Background was transparent and text hard to read. 2omb website doesn't have the issue.

* Set accent color as background for mobile devices

Also i noticed that on mobile, when clicking on the wallet button the menu doesn't close. will create a PR later for that