### PR TITLE
auto close mobile navbar on wallet open

### DIFF
--- a/src/components/Nav/AccountButton.tsx
+++ b/src/components/Nav/AccountButton.tsx
@@ -7,9 +7,10 @@ import AccountModal from './AccountModal';
 
 interface AccountButtonProps {
   text?: string;
+  onOpen?: () => void;
 }
 
-const AccountButton: React.FC<AccountButtonProps> = ({ text }) => {
+const AccountButton: React.FC<AccountButtonProps> = ({ text, onOpen }) => {
   const { account } = useWallet();
   const [onPresentAccountModal] = useModal(<AccountModal />);
 
@@ -17,11 +18,17 @@ const AccountButton: React.FC<AccountButtonProps> = ({ text }) => {
 
   const handleWalletProviderOpen = () => {
     setWalletProviderOpen(true);
+    onOpen && onOpen();
   };
 
   const handleWalletProviderClose = () => {
     setWalletProviderOpen(false);
   };
+
+  const handleAccountModalOpen = () => {
+    onPresentAccountModal()
+    onOpen && onOpen();
+  }
 
   const buttonText = text ? text : 'Unlock';
 
@@ -32,7 +39,7 @@ const AccountButton: React.FC<AccountButtonProps> = ({ text }) => {
           {buttonText}
         </Button>
       ) : (
-        <Button variant="contained" onClick={onPresentAccountModal}>
+        <Button variant="contained" onClick={handleAccountModalOpen}>
           My Wallet
         </Button>
       )}

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -211,7 +211,7 @@ const Nav = () => {
                   <ListItemText>2omb</ListItemText>
                 </ListItem>
                 <ListItem style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                  <AccountButton text="Connect" />
+                  <AccountButton text="Connect" onOpen={handleDrawerClose} />
                 </ListItem>
               </List>
             </Drawer>


### PR DESCRIPTION
QoL fix.

Closes the navbar on mobile when interacting with the wallet/account button.

Best solution for UX I think would be to have that on top of everything, but testing it this works ok